### PR TITLE
[Test] spring sequrity login폼 삭제 및 연동 테스트용 임시 보안 약화

### DIFF
--- a/bilingServer/src/main/java/com/happy/biling/config/SecurityConfig.java
+++ b/bilingServer/src/main/java/com/happy/biling/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.happy.biling.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http.cors(cors -> cors.disable()) // CORS 비활성화
+				.csrf(csrf -> csrf.disable()) // CSRF 비활성화
+				.formLogin(formLogin -> formLogin.disable()) // 기본 로그인 페이지 비활성화
+				.headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable())); // X-Frame-Options
+																									// 비활성화
+		return http.build();
+	}
+
+	@Bean
+	public PasswordEncoder getPasswordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+}


### PR DESCRIPTION
**Check List :memo:**
- [x] Pull Request 제목 : [유형] 변경 사항 요약
- [x] 설명 & 이슈 번호 작성

**설명 (필수)**
- auth api 대신 post api를 먼저 제작함에 따라, post api 토큰 없이 테스트 하기 위해 임시 코드 추가. 추후 보완 예정

1. #6 

2. 변경 사항
- spring boot security login form 삭제
- cors, csrf, x-prame-option 누구나 접근 가능하도록 수정

3. 스크린샷 (선택)

---

**review 참고 사항 (선택)**

1. 추후 auth api 구현 시 cors, csrf, x-prame-option 부분은 다시 살리거나 보완할 예정

