### PR TITLE
Fix: Post 작성시 JWT 토큰에서 userId 추출해내는 코드 추가

### DIFF
--- a/bilingServer/src/main/java/com/happy/biling/controller/PostController.java
+++ b/bilingServer/src/main/java/com/happy/biling/controller/PostController.java
@@ -1,12 +1,19 @@
 package com.happy.biling.controller;
 
+import com.happy.biling.domain.service.KaKaoService;
 import com.happy.biling.domain.service.PostService;
+//import com.happy.biling.dto.post.PostDetailResponseDto;
 import com.happy.biling.dto.post.PostWriteRequestDto;
+import com.happy.biling.security.JwtUtil;
+import org.slf4j.*;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.HttpStatus;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class PostController {
@@ -14,12 +21,32 @@ public class PostController {
     private final PostService postService;
     
     @PostMapping("/posts")
-    public ResponseEntity<Void> createPost(@RequestBody PostWriteRequestDto requestDto) {
+    public ResponseEntity<Void> createPost(
+    		@RequestHeader("Authorization") String authHeader,
+    		@RequestBody PostWriteRequestDto requestDto) {
+    
         try {
+            String token = authHeader.substring(7); // "Bearer " 이후의 토큰 추출
+        	Long userId = Long.valueOf(JwtUtil.getUserIdFromToken(token));
+        	log.info("userId : ",userId.toString());
+        	requestDto.setWriterId(userId);
             postService.createPost(requestDto);
             return ResponseEntity.status(HttpStatus.NO_CONTENT).build(); //성공
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build(); //실패
         }
     }
+    /*
+    @GetMapping("/posts/{id}")
+    public ResponseEntity<PostDetailResponseDto> readPostDetail(
+    		@PathVariable long postId,
+    		@RequestParam(value = "userId", required = false) Long userId) {
+        try {
+            PostDetailResponseDto responseDto = postService.readPostDetail(postId, userId);
+            return ResponseEntity.ok(responseDto);
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+    */
 }

--- a/bilingServer/src/main/java/com/happy/biling/dto/post/PostWriteRequestDto.java
+++ b/bilingServer/src/main/java/com/happy/biling/dto/post/PostWriteRequestDto.java
@@ -1,8 +1,10 @@
 package com.happy.biling.dto.post;
 
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class PostWriteRequestDto {
     private Long writerId; //토큰 생성시 토큰에서 user id 뽑아쓸 수도 있을듯
     private String type; //share borrow

--- a/bilingServer/src/main/java/com/happy/biling/security/JwtAuthenticationFilter.java
+++ b/bilingServer/src/main/java/com/happy/biling/security/JwtAuthenticationFilter.java
@@ -31,8 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = authHeader.substring(7); // "Bearer " 이후의 토큰 추출
         if (jwtUtil.validateToken(token)) {
-            String userId = jwtUtil.getUserIdFromToken(token);
-
+            String userId = JwtUtil.getUserIdFromToken(token);
             // 사용자 인증 정보 설정
             var authentication = new JwtAuthentication(userId);
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));

--- a/bilingServer/src/main/java/com/happy/biling/security/JwtUtil.java
+++ b/bilingServer/src/main/java/com/happy/biling/security/JwtUtil.java
@@ -12,12 +12,12 @@ import java.util.Date;
 public class JwtUtil {
 
     @Value("${jwt.access.secret}")
-    private String secretKey;
+    private static String secretKey;
 
     @Value("${jwt.access.expiration}")
     private long expiration;
 
-    private Key getSigningKey() {
+    private static Key getSigningKey() {
         return Keys.hmacShaKeyFor(secretKey.getBytes());
     }
 
@@ -39,7 +39,7 @@ public class JwtUtil {
         }
     }
 
-    public String getUserIdFromToken(String token) {
+    public static String getUserIdFromToken(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(getSigningKey())
                 .build()


### PR DESCRIPTION
**Check List :memo:**
- [x] Pull Request 제목 : [유형] 변경 사항 요약
- [x] 설명 & 이슈 번호 작성

**설명 (필수)**
기존 writerId를 하드코딩했던 것을 JWT 기능 도입에 따라 토큰에서 userId를 추출해 적용하도록 수정

1. #5 

2. 변경 사항
- JWT 관련 함수들 static 적용
- postController의 posts api 에 JWT에서 userId 추출후 Dto에 세팅하는 코드 추가

4. 스크린샷 (선택)

---

**review 참고 사항 (선택)**

추가로 알릴 내용이 있다면 여기에 작성해주세요.

1.

2.
