### PR TITLE
[Feat] 게시글 삭제/상태 변경 API 구현 및 특정 유저 게시글 목록 가져오기 개선

### DIFF
--- a/bilingServer/src/main/java/com/happy/biling/controller/PostController.java
+++ b/bilingServer/src/main/java/com/happy/biling/controller/PostController.java
@@ -57,6 +57,23 @@ public class PostController {
         }
     }
     
+    // 게시글 상태 변경
+    @PatchMapping("/posts/{id}")
+    public ResponseEntity<PostDetailResponseDto> updatePostStatus(
+            @PathVariable("id") Long id,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestHeader("Authorization") String authHeader) {
+
+        try {
+            String token = authHeader.substring(7); // "Bearer " 이후의 토큰 추출
+            Long userId = Long.valueOf(jwtUtil.getUserIdFromToken(token));
+            postService.updatePostStatus(id, userId, status);
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+    
     // 게시글 생성
     @PostMapping(value = "/posts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> createPost(

--- a/bilingServer/src/main/java/com/happy/biling/controller/PostController.java
+++ b/bilingServer/src/main/java/com/happy/biling/controller/PostController.java
@@ -41,6 +41,22 @@ public class PostController {
         }
     }
     
+    // 게시글 삭제
+    @DeleteMapping("/posts/{id}")
+    public ResponseEntity<PostDetailResponseDto> deletePost(
+            @PathVariable("id") Long id,
+            @RequestHeader("Authorization") String authHeader) {
+
+        try {
+            String token = authHeader.substring(7); // "Bearer " 이후의 토큰 추출
+            Long userId = Long.valueOf(jwtUtil.getUserIdFromToken(token));
+            postService.deletePost(id, userId);
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+    
     // 게시글 생성
     @PostMapping(value = "/posts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> createPost(

--- a/bilingServer/src/main/java/com/happy/biling/controller/UserConroller.java
+++ b/bilingServer/src/main/java/com/happy/biling/controller/UserConroller.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -44,6 +43,7 @@ public class UserConroller {
     @GetMapping("/users/{id}/posts")
     public ResponseEntity<List<PostPreviewResponseDto>> getPostsByUser(
             @PathVariable("id") String userId,
+            @RequestParam(value = "status", required = false) String status,
             @RequestHeader("Authorization") String authHeader) {
 
         try {
@@ -57,7 +57,7 @@ public class UserConroller {
                 userIdToFetch = Long.valueOf(userId);
             }
 
-            List<PostPreviewResponseDto> posts = postService.getPostsByUserId(userIdToFetch);
+            List<PostPreviewResponseDto> posts = postService.getPostsByUserId(userIdToFetch, status);
             return ResponseEntity.ok(posts);
 
         } catch (Exception e) {

--- a/bilingServer/src/main/java/com/happy/biling/domain/repository/PostImageRepository.java
+++ b/bilingServer/src/main/java/com/happy/biling/domain/repository/PostImageRepository.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 public interface PostImageRepository extends JpaRepository<PostImage, Integer> {
     List<PostImage> findAllByPostOrderByOrderSequenceAsc(Post post);
     Optional<PostImage> findTopByPostOrderByOrderSequenceAsc(Post post); // order_sequence가 가장 작은 이미지 조회
+    List<PostImage> findByPost(Post post);
 }

--- a/bilingServer/src/main/java/com/happy/biling/domain/service/PostService.java
+++ b/bilingServer/src/main/java/com/happy/biling/domain/service/PostService.java
@@ -171,13 +171,11 @@ public class PostService {
                     .orElse(null);
 
             FilteredPostPreviewResponseDto responseDto = new FilteredPostPreviewResponseDto();
-            responseDto.setPostStatus(post.getStatus().name());
             responseDto.setPostId(post.getId());
             responseDto.setTitle(post.getTitle());
             responseDto.setPrice(post.getPrice());
             responseDto.setPreviewImage(previewImage);
             responseDto.setLocationName(post.getLocationName());
-            responseDto.setPostType(post.getType().name());
             
             return responseDto;
         }).collect(Collectors.toList());

--- a/bilingServer/src/main/java/com/happy/biling/domain/service/PostService.java
+++ b/bilingServer/src/main/java/com/happy/biling/domain/service/PostService.java
@@ -6,6 +6,7 @@ import com.happy.biling.domain.entity.Review;
 import com.happy.biling.domain.entity.User;
 import com.happy.biling.domain.entity.enums.Category;
 import com.happy.biling.domain.entity.enums.Distance;
+import com.happy.biling.domain.entity.enums.PostStatus;
 import com.happy.biling.domain.entity.enums.PostType;
 import com.happy.biling.domain.repository.PostImageRepository;
 import com.happy.biling.domain.repository.PostRepository;
@@ -97,6 +98,20 @@ public class PostService {
 
         // 게시글 삭제
         postRepository.delete(post);
+    }
+    
+    public void updatePostStatus(Long postId, Long userId, String status) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("Post not found"));
+        
+        if (!post.getWriter().getId().equals(userId)) {
+            throw new IllegalArgumentException("You are not the writer of this post");
+        }
+        
+        PostStatus newStatus = PostStatus.valueOf(status);
+        post.setStatus(newStatus);;
+        
+        postRepository.save(post);
     }
     
     public PostDetailResponseDto getPostDetail(Long postId, Long userId) {

--- a/bilingServer/src/main/java/com/happy/biling/domain/service/PostService.java
+++ b/bilingServer/src/main/java/com/happy/biling/domain/service/PostService.java
@@ -75,6 +75,30 @@ public class PostService {
         return post;
     }
     
+    public void deletePost(Long postId, Long userId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("Post not found"));
+        
+        if (!post.getWriter().getId().equals(userId)) {
+            throw new IllegalArgumentException("You are not the writer of this post");
+        }
+
+        if ("거래완료".equals(post.getStatus().name())) {
+            throw new IllegalStateException("Cannot delete a post with status '거래완료'");
+        }
+
+        //TODO 포스트와 연관된 채팅이 있을 때도 삭제하면 안되나? 거래완료를 못 지우게 하면 리뷰 같은 건 자동적으로 고려하긴 함
+        
+        // postImage 삭제
+        List<PostImage> postImages = postImageRepository.findByPost(post);
+        if (!postImages.isEmpty()) {
+            postImageRepository.deleteAll(postImages);
+        }
+
+        // 게시글 삭제
+        postRepository.delete(post);
+    }
+    
     public PostDetailResponseDto getPostDetail(Long postId, Long userId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new RuntimeException("Post not found"));

--- a/bilingServer/src/main/java/com/happy/biling/dto/post/FilteredPostPreviewResponseDto.java
+++ b/bilingServer/src/main/java/com/happy/biling/dto/post/FilteredPostPreviewResponseDto.java
@@ -8,13 +8,11 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 public class FilteredPostPreviewResponseDto {
-    private String postStatus; //거래중, 대여중 , 거래완료
     private Long postId;          // 게시글 ID
     private String title;         // 게시글 제목
     private Integer price;        // 가격
     private String previewImage;  // 대표 이미지 URL
     private String locationName;  // 위치 이름
-    private String postType;  // 빌려드려요/빌려주세요
 }
 
 


### PR DESCRIPTION
**Check List :memo:**
- [x] Pull Request 제목 : [유형] 변경 사항 요약
- [x] 설명 & 이슈 번호 작성

**설명 (필수)**
- 게시글 삭제 API 구현
- 게시글 상태 변경 API 구현
- 유저 게시글 목록 가져올 시 status로 필터링하여 가져올 수 있도록 수정
- 전체 게시글 반환 시 각 포스트 객체에서 PostStatus, PostType 반환하지 않도록 수정

1. #5 

2. 변경 사항
- 게시글 삭제 API 구현 - a7689a2 커밋 참조
- 게시글 상태 변경 API 구현 - ec0b566 커밋 참조
- 유저 게시글 목록 가져올 시 status로 필터링하여 가져올 수 있도록 수정 - 6361c32 커밋 참조
- 전체 게시글 반환 시 각 포스트 객체에서 PostStatus, PostType 반환하지 않도록 수정 - 6bd1cb5 커밋 참조

3. 스크린샷 (선택)
